### PR TITLE
Added GitIgnore

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,23 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
Added a gitignore file to the server side. This will hide the node_modules folder from github, since Node will download the necessary modules anyways, saving time and space.